### PR TITLE
Don't call log.Fatal, use panic().

### DIFF
--- a/epsilon_greedy.go
+++ b/epsilon_greedy.go
@@ -1,6 +1,7 @@
 package hostpool
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"time"
@@ -185,7 +186,7 @@ func (p *epsilonGreedyHostPool) markSuccess(hostR HostPoolResponse) {
 	defer p.Unlock()
 	h, ok := p.hosts[host]
 	if !ok {
-		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
+		panic(fmt.Sprintf("host %s not in HostPool %v", host, p.Hosts()))
 	}
 	h.epsilonCounts[h.epsilonIndex]++
 	h.epsilonValues[h.epsilonIndex] += int64(duration.Seconds() * 1000)

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 package hostpool
 
 import (
-	"github.com/bitly/go-hostpool"
+	"github.com/hailocab/go-hostpool"
 )
 
 func ExampleNewEpsilonGreedy() {

--- a/hostpool.go
+++ b/hostpool.go
@@ -4,7 +4,7 @@
 package hostpool
 
 import (
-	"log"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -183,7 +183,7 @@ func (p *standardHostPool) markSuccess(hostR HostPoolResponse) {
 
 	h, ok := p.hosts[host]
 	if !ok {
-		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
+		panic(fmt.Sprintf("host %s not in HostPool %v", host, p.Hosts()))
 	}
 	h.dead = false
 }
@@ -194,7 +194,7 @@ func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
 	defer p.Unlock()
 	h, ok := p.hosts[host]
 	if !ok {
-		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
+		panic(fmt.Sprintf("host %s not in HostPool %v", host, p.Hosts()))
 	}
 	if !h.dead {
 		h.dead = true


### PR DESCRIPTION
Usually it's not good idea for library to abort process execution
even if error is fatal. Panic seems to be much better choice.